### PR TITLE
Fix the code block display in github

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -47,11 +47,11 @@ Redmine Wiki Graphviz-macro plugin will allow Redmine's wiki to render graph ima
 * This macro render graph image having passing the dot description inline. 
 
     {{graphviz_link()
-	digraph G {...}
-	}}
+    digraph G {...}
+    }}
     {{graphviz_link(option=value)
-	digraph G {...}
-	}}
+    digraph G {...}
+    }}
 
 * options: See graphviz macro.
 


### PR DESCRIPTION
It seems that github doesn't support indent by tabs in the code block,
so the rendering HTML is not so good.

Please compare [here](https://github.com/sayuan/redmine-wiki_graphviz_plugin#graphviz_link-macro) & [here](https://github.com/tckz/redmine-wiki_graphviz_plugin#graphviz_link-macro).
