### PR TITLE
use get in routes instead of match

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 RedmineApp::Application.routes.draw do
-	match 'projects/:project_id/wiki/:id/graphviz', :to => 'wiki_graphviz#graphviz'
+	get 'projects/:project_id/wiki/:id/graphviz', :to => 'wiki_graphviz#graphviz'
 end
 
 # vim: set ts=2 sw=2 sts=2:


### PR DESCRIPTION
Redmine 3.0.0 complained about match in routes and according to the Rails docs we should either specify the HTTP methods for match or use an explicit route, so I modified it to get.